### PR TITLE
fix manage.py syntax issue

### DIFF
--- a/aligulac/ratings/models.py
+++ b/aligulac/ratings/models.py
@@ -1343,8 +1343,7 @@ class Group(models.Model):
             "is_team": True
         }
         q = Group.objects.filter(**filters) \
-            .exclude(id=self.id) \
- \
+            .exclude(id=self.id)
         c = q.count()
         self._ranks[rank_type] = c + 1
         return self._ranks[rank_type]


### PR DESCRIPTION
This pull request makes a minor cleanup to the `get_rank` method in `aligulac/ratings/models.py`, removing an unnecessary line continuation for improved code readability.

* Minor code cleanup:
  * Removed an unnecessary line continuation character in the `get_rank` method of `aligulac/ratings/models.py`.