### PR TITLE
small bugfixes and updates for dockerized deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ aligulac/bugrep/
 
 # Virtualenv
 .venv
+.env

--- a/aligulac/aligulac/tools.py
+++ b/aligulac/aligulac/tools.py
@@ -1,4 +1,5 @@
 # {{{ Imports
+import os
 import json
 import random
 import shlex
@@ -345,12 +346,24 @@ def base_ctx(section=None, subpage=None, request=None, context=None):
                 add_subnav(_('Adjustments'), base_url + 'period/%i/' % rating.period.id)
 
     if DEBUG:
-        p = subprocess.Popen(['git', '-C', PROJECT_PATH, 'rev-parse', 'HEAD'], stdout=subprocess.PIPE)
-        base['commithash'] = p.communicate()[0].decode().strip()[:8]
+        base['commithash'] = os.environ.get('COMMIT_HASH', '')
+        base['commitbranch'] = os.environ.get('COMMIT_BRANCH', '')
 
-        p = subprocess.Popen(['git', '-C', PROJECT_PATH, 'rev-parse', '--abbrev-ref', 'HEAD'],
-                             stdout=subprocess.PIPE)
-        base['commitbranch'] = p.communicate()[0].decode().strip()
+        if not base['commithash'] or not base['commitbranch']:
+            try:
+                p = subprocess.Popen(['git', '-C', PROJECT_PATH, 'rev-parse', 'HEAD'],
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate()
+                if out:
+                    base['commithash'] = out.decode().strip()[:8]
+
+                p = subprocess.Popen(['git', '-C', PROJECT_PATH, 'rev-parse', '--abbrev-ref', 'HEAD'],
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate()
+                if out:
+                    base['commitbranch'] = out.decode().strip()
+            except (FileNotFoundError, subprocess.SubprocessError):
+                pass
 
     return base
 


### PR DESCRIPTION
This pull request updates how commit metadata is retrieved for debugging purposes, making the process more robust and configurable. Now, the code first checks for environment variables before falling back to running git commands, and it improves error handling if git is not available.

**Improvements to commit metadata retrieval:**

* The retrieval of `commithash` and `commitbranch` in `add_subnav` now first checks the `COMMIT_HASH` and `COMMIT_BRANCH` environment variables, allowing easier integration with deployment pipelines. If these are not set, it falls back to using git commands as before.
* Added error handling to gracefully skip git commands if the git executable is not available or if a subprocess error occurs, preventing potential crashes in environments without git.
* Added `import os` to support reading environment variables.