### PR TITLE
add buildx to resolve builder issue w/docker driver

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This pull request makes a small update to the Docker publishing workflow by adding a step to set up Docker Buildx. This change prepares the workflow for advanced Docker build features and multi-platform builds.

* Added a `Set up Docker Buildx` step in the `.github/workflows/docker-publish.yml` workflow to enable advanced Docker build capabilities.