### PR TITLE
reduce cache times, improve theme selector

### DIFF
--- a/aligulac/aligulac/default.settings.py
+++ b/aligulac/aligulac/default.settings.py
@@ -69,21 +69,21 @@ CACHE_TIMES = {
     'aligulac.views.h500': 24 * 60 * 60,
     'ratings.inference_views.predict': 24 * 60 * 60,
 
-    # Views that change only after the quad-daily update can have six hours cache times
+    # Views that change only after the quad-daily update can have fifteen minutes cache times
     # These typically depend on ratings, but not on specific results
-    'aligulac.views.home': 6 * 60 * 60,
-    'aligulac.views.home': 6 * 60 * 60,
-    'ratings.inference_views.dual': 6 * 60 * 60,
-    'ratings.inference_views.sebracket': 6 * 60 * 60,
-    'ratings.inference_views.rrgroup': 6 * 60 * 60,
-    'ratings.inference_views.proleague': 6 * 60 * 60,
-    'ratings.player_views.historical': 6 * 60 * 60,
-    'ratings.ranking_views.periods': 6 * 60 * 60,
-    'ratings.ranking_views.period': 6 * 60 * 60,
-    'ratings.records_views.history': 6 * 60 * 60,
-    'ratings.records_views.hof': 6 * 60 * 60,
-    'ratings.records_views.race': 6 * 60 * 60,
-    'ratings.report_views.balance': 6 * 60 * 60,
+    'aligulac.views.home': 15 * 60,
+    'ratings.inference_views.dual': 15 * 60,
+    'ratings.inference_views.sebracket': 15 * 60,
+    'ratings.inference_views.rrgroup': 15 * 60,
+    'ratings.inference_views.proleague': 15 * 60,
+    'ratings.player_views.historical': 15 * 60,
+    'ratings.ranking_views.periods': 15 * 60,
+    'ratings.ranking_views.period': 15 * 60,
+    'ratings.records_views.history': 15 * 60,
+    'ratings.records_views.hof': 15 * 60,
+    'ratings.records_views.race': 15 * 60,
+    'ratings.report_views.balance': 15 * 60,
+    'blog.views.blog': 15 * 60,
 
     # Depends on results but not urgent
     'ratings.misc_views.clocks': 30 * 60,

--- a/aligulac/aligulac/settings.py
+++ b/aligulac/aligulac/settings.py
@@ -99,20 +99,21 @@ CACHE_TIMES = {
     'aligulac.views.h500': 24 * 60 * 60,
     'ratings.inference_views.predict': 24 * 60 * 60,
 
-    # Views that change only after the quad-daily update can have six hours cache times
+    # Views that change only after the quad-daily update can have fifteen minutes cache times
     # These typically depend on ratings, but not on specific results
-    'aligulac.views.home': 6 * 60 * 60,
-    'ratings.inference_views.dual': 6 * 60 * 60,
-    'ratings.inference_views.sebracket': 6 * 60 * 60,
-    'ratings.inference_views.rrgroup': 6 * 60 * 60,
-    'ratings.inference_views.proleague': 6 * 60 * 60,
-    'ratings.player_views.historical': 6 * 60 * 60,
-    'ratings.ranking_views.periods': 6 * 60 * 60,
-    'ratings.ranking_views.period': 6 * 60 * 60,
-    'ratings.records_views.history': 6 * 60 * 60,
-    'ratings.records_views.hof': 6 * 60 * 60,
-    'ratings.records_views.race': 6 * 60 * 60,
-    'ratings.report_views.balance': 6 * 60 * 60,
+    'aligulac.views.home': 15 * 60,
+    'ratings.inference_views.dual': 15 * 60,
+    'ratings.inference_views.sebracket': 15 * 60,
+    'ratings.inference_views.rrgroup': 15 * 60,
+    'ratings.inference_views.proleague': 15 * 60,
+    'ratings.player_views.historical': 15 * 60,
+    'ratings.ranking_views.periods': 15 * 60,
+    'ratings.ranking_views.period': 15 * 60,
+    'ratings.records_views.history': 15 * 60,
+    'ratings.records_views.hof': 15 * 60,
+    'ratings.records_views.race': 15 * 60,
+    'ratings.report_views.balance': 15 * 60,
+    'blog.views.blog': 15 * 60,
 
     # Depends on results but not urgent
     'ratings.misc_views.clocks': 30 * 60,

--- a/resources/css/aligulac.css
+++ b/resources/css/aligulac.css
@@ -100,6 +100,11 @@
     --transition-speed: 0.2s;
 }
 
+.theme-link.active {
+    font-weight: bold;
+    text-decoration: underline;
+}
+
 [data-theme='dark'] {
     /* Colors - Dark Theme Overrides - Vivid Midnight (REPLAYMAN inspired) */
     --bg-primary: #110022;

--- a/templates/index.djhtml
+++ b/templates/index.djhtml
@@ -39,8 +39,13 @@ To use, you should define the following blocks:
     <script type="text/javascript">
       (function() {
         try {
-          var theme = localStorage.getItem('theme') || 'light';
-          document.documentElement.setAttribute('data-theme', theme);
+          var theme = localStorage.getItem('theme') || 'system';
+          var resolvedTheme = theme;
+          if (theme === 'system') {
+            resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          document.documentElement.setAttribute('data-theme', resolvedTheme);
+          document.documentElement.setAttribute('data-user-theme', theme);
         } catch (e) {}
       })();
     </script>    <link href='https://fonts.googleapis.com/css?family=Marcellus+SC' rel='stylesheet' type='text/css'>
@@ -168,23 +173,49 @@ To use, you should define the following blocks:
             All data provided by this site is free for non-commercial use.</p>
 
 
-            <p><a href="/about/acknowledgements/">{% trans "Acknowledgements" %}</a> &nbsp;|&nbsp; <a target="_blank" href="https://twitter.com/Sc2Aligulac">Twitter</a> &nbsp;|&nbsp; <a target="_blank" href="https://discord.gg/723Df2yaaw">Discord</a> &nbsp;|&nbsp; <a href="#" id="theme-toggle">{% trans "Toggle Dark Mode" %}</a></p>
+            <p>
+              <a href="/about/acknowledgements/">{% trans "Acknowledgements" %}</a> &nbsp;|&nbsp; 
+              <a target="_blank" href="https://twitter.com/Sc2Aligulac">Twitter</a> &nbsp;|&nbsp; 
+              <a target="_blank" href="https://discord.gg/723Df2yaaw">Discord</a> &nbsp;|&nbsp; 
+              <span class="theme-selector">
+                {% trans "Theme" %}: 
+                <a href="#" class="theme-link" data-theme-set="light">{% trans "Light" %}</a> | 
+                <a href="#" class="theme-link" data-theme-set="dark">{% trans "Dark" %}</a> | 
+                <a href="#" class="theme-link" data-theme-set="system">{% trans "System" %}</a>
+              </span>
+            </p>
 
             <span id="disp_short"></span>
             <script type="text/javascript">
-              document.getElementById('theme-toggle').addEventListener('click', function(e) {
-                e.preventDefault();
-                try {
-                  var currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
-                  var newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-                  localStorage.setItem('theme', newTheme);
-                  window.location.reload();
-                } catch (err) {
-                  var currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
-                  var newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-                  document.documentElement.setAttribute('data-theme', newTheme);
-                }
-              });
+              (function() {
+                var userTheme = localStorage.getItem('theme') || 'system';
+                document.querySelectorAll('.theme-link').forEach(function(el) {
+                  if (el.getAttribute('data-theme-set') === userTheme) {
+                    el.classList.add('active');
+                  }
+                  el.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    var newTheme = this.getAttribute('data-theme-set');
+                    try {
+                      localStorage.setItem('theme', newTheme);
+                      window.location.reload();
+                    } catch (err) {
+                      var resolvedTheme = newTheme;
+                      if (newTheme === 'system') {
+                        resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                      }
+                      document.documentElement.setAttribute('data-theme', resolvedTheme);
+                      document.documentElement.setAttribute('data-user-theme', newTheme);
+                    }
+                  });
+                });
+
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+                  if (localStorage.getItem('theme') === 'system' || !localStorage.getItem('theme')) {
+                    window.location.reload();
+                  }
+                });
+              })();
             </script>          </footer>
         </div>
       </div>
@@ -261,7 +292,12 @@ To use, you should define the following blocks:
        (function() {
          var isDark = false;
          try {
-           isDark = localStorage.getItem('theme') === 'dark';
+           var theme = localStorage.getItem('theme') || 'system';
+           if (theme === 'system') {
+             isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+           } else {
+             isDark = theme === 'dark';
+           }
          } catch (e) {}
          var chartTheme = {
            colors: isDark ? ["#221133", "#00dd00", "#0000dd", "#dd0000", "#ffeeff", "#ffaa00", "#FF0000"] : ["rgba(140,140,140,0.4)", "#00dd00", "#0000dd", "#dd0000", "#000000", "#ffaa00", "#FF0000"],


### PR DESCRIPTION
This pull request introduces several improvements to theme selection and caching behavior across the application. The most significant changes are the redesign of the theme selector to allow explicit choice between light, dark, and system themes, and a reduction in cache times for several views from six hours to fifteen minutes. These updates enhance user experience by providing more flexible theme options and ensure that content reflects updates more promptly.

**Theme selection improvements:**

* Replaced the "Toggle Dark Mode" link in the footer with a new theme selector, allowing users to explicitly choose between "Light", "Dark", or "System" themes. The active theme is visually indicated, and the selection is persisted in `localStorage`. [[1]](diffhunk://#diff-93ee6ed023213829b4d2e08f27459926134eda1e2da411054941e06a8180fea7L171-R218) [[2]](diffhunk://#diff-d54f128dbb99632369c0b2c052ba70ee71d77ad4b9ab29961bc9fcfb8dafd704R103-R107)
* Updated the theme initialization script to resolve the "system" theme by detecting the user's OS preference and to store both the resolved and user-selected themes as attributes on the `document.documentElement`.
* Modified chart color logic to respect the user's theme selection, including the "system" option, for consistent appearance across the site.

**Cache time reductions:**

* Reduced the cache duration for several views (including `aligulac.views.home`, `ratings.ranking_views.period`, and others) from six hours to fifteen minutes, ensuring that updates are reflected more quickly. Also added `blog.views.blog` to the list of cached views with a fifteen-minute duration. [[1]](diffhunk://#diff-fc543eeb5029fc980f92e06e4e4a1f9438cb9fa654878dd2c28e55fcaf359bd8L72-R86) [[2]](diffhunk://#diff-4fd2b56ed469ad140148e2d58af18a303662d63a0096254e0be5c8bddbdd740dL102-R116)