### PR TITLE
Minor layout and color updates to match list

### DIFF
--- a/aligulac/ratings/templatetags/race_icons.py
+++ b/aligulac/ratings/templatetags/race_icons.py
@@ -49,11 +49,11 @@ def race_icon(race, size=24, cls=""):
     names = {'T': 'Terran', 'Z': 'Zerg', 'P': 'Protoss', 'R': 'Random', 'S': 'Switcher'}
     name = names.get(race, race)
 
-    # Scale Protoss slightly differently to match visual weight, like in REPLAYMAN
+    # We want a fixed width for all icons to ensure alignment.
+    # Protoss is taller but we'll center it within the standard width.
     width = size
     height = size
     if race == 'P':
-        width = int(size * 0.85)
         height = int(size * 1.2)
 
     svg = f"""<svg 
@@ -63,9 +63,10 @@ def race_icon(race, size=24, cls=""):
     xmlns="http://www.w3.org/2000/svg"
     fill="currentColor"
     class="race-icon race-{race.lower()} {cls}"
-    style="vertical-align: middle; margin-right: 0.25em;"
+    style="vertical-align: middle; display: inline-block; width: {width}px;"
     role="img"
     aria-label="{name}"
+    preserveAspectRatio="xMidYMid meet"
 >
     <title>{name}</title>
     {data['path']}

--- a/aligulac/ratings/templatetags/ratings_extras.py
+++ b/aligulac/ratings/templatetags/ratings_extras.py
@@ -386,7 +386,7 @@ def flag(value):
 
     # Use the value as the label for accessibility
     label = value.upper()
-    return mark_safe(f'<span class="fi fi-{final_code}" role="img" aria-label="{label}" title="{label}" style="margin-right: 0.25em;"></span>')
+    return mark_safe(f'<span class="fi fi-{final_code}" role="img" aria-label="{label}" title="{label}"></span>')
 
 # img: Generates a png-image file URL
 @register.filter

--- a/resources/css/aligulac.css
+++ b/resources/css/aligulac.css
@@ -113,11 +113,11 @@
     
     --fg-primary: #ffeeff;
     --fg-secondary: #dccbed;
-    --fg-muted: rgba(220, 203, 237, 0.7);
+    --fg-muted: rgb(128, 119, 136);
     --fg-disabled: rgba(220, 203, 237, 0.5);
     
-    --link-color: #dccbed;
-    --link-hover-color: #ffeeff;
+    --link-color: #eddbf6;
+    --link-hover-color: #fffeff;
     
     --border-color: rgba(220, 203, 237, 0.15);
     --border-dark: #090014;
@@ -730,8 +730,10 @@ footer {
 .lm_date { width: 17%; }
 .lm_rta { text-align: right; width: 3.5em; }
 .lm_pla { text-align: right; width: 23%; }
+th.lm_pla { padding-right: 2em !important; } /* Align "Player A" header text end with flag */
 .lm_score { width: 7em; text-align: center; }
 .lm_plb { width: 23%; }
+th.lm_plb { padding-left: 2em !important; } /* Align "Player B" header text start with flag */
 .lm_rtb { text-align: right; width: 3.5em; }
 .lm_right { text-align: right; width: 17%; }
 
@@ -850,15 +852,39 @@ div.text, div.text > p, div.text > ul > li { text-align: justify; }
     border-right-color: var(--border-color);
 }
 
-/* Keep race and flag icons apart */
-.player img, .ui-corner-all img, .lm_plb img, .player .fi, .ui-corner-all .fi, .lm_plb .fi { padding-right: 0.3em; }
-.playerleft img, .lm_pla img, .playerleft .fi, .lm_pla .fi { padding-left: 0.3em; }
+/* Keep race, flag and trophy icons consistently aligned and spaced */
+.fi, .race-icon, .winner-trophy {
+    vertical-align: middle;
+    display: inline-block;
+    position: relative;
+    top: -0.05em; /* Subtle adjustment to pull icons up for better visual centering with text */
+}
+
+/* Default gap to the right for icons before text */
+.fi, .race-icon { margin-right: 0.3em; }
+
+/* Mirror player blocks and left-aligned match list elements ([Tag][Icon]) */
+.playerleft .race-icon, .playerleft .fi,
+.lm_pla .fi, .lm_pla .race-icon {
+    margin-right: 0;
+    margin-left: 0.3em;
+}
+
+/* Trophy gaps in match list */
+.lm_pla .winner-trophy { margin-right: 0; }
+.lm_plb .winner-trophy { margin-left: 0; }
+
+/* Remove margins for icon-only cells in rankings and tables to keep them centered */
+.rl_icon .fi, .rl_icon .race-icon,
+.ho_icon .fi, .ho_icon .race-icon,
+.ea_icon .fi, .ea_icon .race-icon,
+.pp_icon .fi, .pp_icon .race-icon {
+    margin: 0;
+}
 
 .fi {
-    vertical-align: middle;
     width: 1.33333333em;
     line-height: 1em;
-    display: inline-block;
 }
 
 /* Event manager tree */

--- a/resources/css/aligulac.css
+++ b/resources/css/aligulac.css
@@ -116,7 +116,7 @@
     --fg-muted: rgb(128, 119, 136);
     --fg-disabled: rgba(220, 203, 237, 0.5);
     
-    --link-color: #eddbf6;
+    --link-color: #f4e3ff;
     --link-hover-color: #fffeff;
     
     --border-color: rgba(220, 203, 237, 0.15);

--- a/templates/index.djhtml
+++ b/templates/index.djhtml
@@ -90,16 +90,15 @@ To use, you should define the following blocks:
        var iconSize = size || 16;
        if (!race_svgs || !race_svgs[race]) {
          /* Fallback to legacy img if SVGs aren't loaded */
-         return '<img src="' + races_dir + race + '.png" width="' + iconSize + '" height="' + iconSize + '" alt="' + raceName + '" title="' + raceName + '" style="margin-right: 0.25em;" />';
+         return '<img src="' + races_dir + race + '.png" width="' + iconSize + '" height="' + iconSize + '" alt="' + raceName + '" title="' + raceName + '" style="vertical-align: middle;" />';
        }
        var data = race_svgs[race];
        var width = iconSize;
        var height = iconSize;
        if (race === 'P') {
-         width = Math.round(iconSize * 0.85);
          height = Math.round(iconSize * 1.2);
        }
-       return '<svg width="' + width + '" height="' + height + '" viewBox="' + data.viewBox + '" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="race-icon race-' + race.toLowerCase() + '" style="vertical-align: middle; margin-right: 0.25em;" role="img" aria-label="' + raceName + '"><title>' + raceName + '</title>' + data.path + '</svg>';
+       return '<svg width="' + width + '" height="' + height + '" viewBox="' + data.viewBox + '" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="race-icon race-' + race.toLowerCase() + '" style="vertical-align: middle; display: inline-block; width: ' + width + 'px;" role="img" aria-label="' + raceName + '" preserveAspectRatio="xMidYMid meet"><title>' + raceName + '</title>' + data.path + '</svg>';
 
      }
      window.getFlag = getFlag;

--- a/templates/matchlist.djhtml
+++ b/templates/matchlist.djhtml
@@ -183,6 +183,11 @@ In general, if you're trying to figure out how this works, may God have mercy on
                 {% if m.pla.rating %}{{ m.pla.rating|ratscale }}{% endif %}
               </td>
               <td class="lm_pla {% if m.pla.score >= m.plb.score %}winner{% else %}loser{% endif %}" style="vertical-align: middle;">
+                {% if m.pla.score > m.plb.score %}
+                  <svg xmlns="http://www.w3.org/2000/svg" height="14px" viewBox="0 -960 960 960" width="14px" fill="currentColor" class="winner-trophy" style="vertical-align: middle;">
+                    <path d="M280-120v-80h160v-124q-49-11-87.5-41.5T296-442q-75-9-125.5-65.5T120-640v-40q0-33 23.5-56.5T200-760h80v-80h400v80h80q33 0 56.5 23.5T840-680v40q0 76-50.5 132.5T664-442q-18 46-56.5 76.5T520-324v124h160v80H280Zm0-408v-152h-80v40q0 38 22 68.5t58 43.5Zm285 93q35-35 35-85v-240H360v240q0 50 35 85t85 35q50 0 85-35Zm115-93q36-13 58-43.5t22-68.5v-40h-80v152Zm-200-52Z"/>
+                  </svg>
+                {% endif %}
                 {% if m.pla.id %}
                   <a href="/players/{{ m.pla.id }}-{{ m.pla.tag|urlfilter }}/">{{m.pla.tag}}</a>
                 {% endif %}
@@ -233,6 +238,11 @@ In general, if you're trying to figure out how this works, may God have mercy on
                     <input type="text" class="form-control" name="match-{{ m.match_id }}-plb"
                            value="{{ m.plb.tag }}" style="display: inline-block; width: auto; vertical-align: middle;">
                   </div>
+                {% endif %}
+                {% if m.plb.score > m.pla.score %}
+                  <svg xmlns="http://www.w3.org/2000/svg" height="14px" viewBox="0 -960 960 960" width="14px" fill="currentColor" class="winner-trophy" style="vertical-align: middle;">
+                    <path d="M280-120v-80h160v-124q-49-11-87.5-41.5T296-442q-75-9-125.5-65.5T120-640v-40q0-33 23.5-56.5T200-760h80v-80h400v80h80q33 0 56.5 23.5T840-680v40q0 76-50.5 132.5T664-442q-18 46-56.5 76.5T520-324v124h160v80H280Zm0-408v-152h-80v40q0 38 22 68.5t58 43.5Zm285 93q35-35 35-85v-240H360v240q0 50 35 85t85 35q50 0 85-35Zm115-93q36-13 58-43.5t22-68.5v-40h-80v152Zm-200-52Z"/>
+                  </svg>
                 {% endif %}
               </td>
               <td class="lm_rtb">


### PR DESCRIPTION
NOTES: 

- Increased contrast for winner and loser names on the results lists
- Decreased saturation for loser to make it more visually distinct and intuitive
- Evened out padding around flags for a more even appearance
- Adjusted alignment of flags, icons, names, and other elements slightly, to make it feel more visually consistent
- Added a small trophy icon next to winner names on the outside edge
- Adjusted header spacing to make it less crowded at the center

OLD

<img width="2014" height="986" alt="image" src="https://github.com/user-attachments/assets/2d229f73-8db6-4b21-a4b3-cb1a9a1f0a59" />


NEW

<img width="975" height="501" alt="image" src="https://github.com/user-attachments/assets/57d78e96-0c71-40c5-9616-d77e84f9633a" />

