### PR TITLE
Hotfix/concurrent task safety

### DIFF
--- a/aligulac/recompute.py
+++ b/aligulac/recompute.py
@@ -12,27 +12,27 @@ import django
 
 django.setup()
 
-# --- Concurrency & Timeout Protection ---
+TIMEOUT_SECONDS = 28800
+RECOMPUTE_LOCK_ID = 837264
+
 def timeout_handler(signum, frame):
     print('[%s] FATAL: Recompute task timed out after 8 hours. Terminating.' % str(datetime.now()), flush=True)
     sys.exit(1)
 
-# Set an 8-hour timeout (28800 seconds)
 signal.signal(signal.SIGALRM, timeout_handler)
-signal.alarm(28800)
+signal.alarm(TIMEOUT_SECONDS)
 
 from django.db import connection
 
 def acquire_lock():
     with connection.cursor() as cursor:
-        cursor.execute("SELECT pg_try_advisory_lock(837264);")
-        row = cursor.fetchone()
-        if not row[0]:
+        cursor.execute("SELECT pg_try_advisory_lock(%s);", [RECOMPUTE_LOCK_ID])
+        (locked,) = cursor.fetchone()
+        if not locked:
             print('[%s] Another recompute task is already running. Exiting.' % str(datetime.now()), flush=True)
             sys.exit(0)
 
 acquire_lock()
-# ----------------------------------------
 
 from django.db.models import F, Q
 from django.db.transaction import atomic
@@ -45,11 +45,11 @@ print('[%s] Checking for Match <-> Period artifacts... ' % (str(datetime.now()))
 
 q = Match.objects.exclude(period__start__lte=F('date'), period__end__gte=F('date'))
 
-if q.count() > 0:
+matches = list(q)
+
+if matches:
     print('Found!')
     print('[%s] Fixing artifacts... ' % str(datetime.now()))
-
-    matches = list(q)
 
     period_set = set()
 
@@ -165,13 +165,13 @@ if 'debug' not in sys.argv:
         g += 1
 
     print('[%s] Refreshing miscellaneous data' % str(datetime.now()), flush=True)
-    cur = connection.cursor()
-    cur.execute('UPDATE event SET earliest = (SELECT MIN(date) FROM match JOIN eventadjacency '
-                'ON match.eventobj_id=eventadjacency.child_id WHERE eventadjacency.parent_id=event.id)')
-    cur.execute('UPDATE event SET latest   = (SELECT MAX(date) FROM match JOIN eventadjacency '
-                'ON match.eventobj_id=eventadjacency.child_id WHERE eventadjacency.parent_id=event.id)')
-    cur.execute('UPDATE player SET current_rating_id = (SELECT rating.id FROM rating '
-                'WHERE rating.period_id=%i AND rating.player_id=player.id)' % latest.id)
+    with connection.cursor() as cur:
+        cur.execute('UPDATE event SET earliest = (SELECT MIN(date) FROM match JOIN eventadjacency '
+                    'ON match.eventobj_id=eventadjacency.child_id WHERE eventadjacency.parent_id=event.id)')
+        cur.execute('UPDATE event SET latest   = (SELECT MAX(date) FROM match JOIN eventadjacency '
+                    'ON match.eventobj_id=eventadjacency.child_id WHERE eventadjacency.parent_id=event.id)')
+        cur.execute('UPDATE player SET current_rating_id = (SELECT rating.id FROM rating '
+                    'WHERE rating.period_id=%s AND rating.player_id=player.id)', [latest.id])
 
     os.system(os.path.join(PROJECT_PATH, 'event_sort.py'))
 

--- a/aligulac/recompute.py
+++ b/aligulac/recompute.py
@@ -1,18 +1,39 @@
 #!/usr/bin/env python3
 
 import os
+from datetime import date, datetime
+import itertools
+import signal
+import sys
+import subprocess
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'aligulac.settings')
 import django
 
 django.setup()
 
-from datetime import date, datetime
-import itertools
-import sys
-import subprocess
+# --- Concurrency & Timeout Protection ---
+def timeout_handler(signum, frame):
+    print('[%s] FATAL: Recompute task timed out after 8 hours. Terminating.' % str(datetime.now()), flush=True)
+    sys.exit(1)
+
+# Set an 8-hour timeout (28800 seconds)
+signal.signal(signal.SIGALRM, timeout_handler)
+signal.alarm(28800)
 
 from django.db import connection
+
+def acquire_lock():
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_try_advisory_lock(837264);")
+        row = cursor.fetchone()
+        if not row[0]:
+            print('[%s] Another recompute task is already running. Exiting.' % str(datetime.now()), flush=True)
+            sys.exit(0)
+
+acquire_lock()
+# ----------------------------------------
+
 from django.db.models import F, Q
 from django.db.transaction import atomic
 


### PR DESCRIPTION
This adds concurrency locking and a last-resort timeout to the recompute task to prevent a cascading failure of multiple scheduled tasks overlapping.

**Reliability and concurrency improvements:**
- Added an 8-hour timeout using `signal.alarm()` and a handler to ensure the recompute task does not run indefinitely.
- Implemented a PostgreSQL advisory lock (`pg_try_advisory_lock`) to prevent multiple recompute tasks from running at the same time. If the lock cannot be acquired, the script exits gracefully.

**Database and code quality improvements:**
- Replaced direct cursor usage with `with connection.cursor() as cur:` for better resource management and safety.
- Updated SQL parameterization in the `UPDATE player SET current_rating_id` statement to use parameterized queries instead of string interpolation, improving security and compatibility.

**Code cleanup:**
- Improved the logic for checking and processing matches by converting the queryset to a list before checking for results, making the code more Pythonic and efficient.