### PR TITLE
fix: request-scoped DB statement_timeout so slow queries don't SIGABRT gunicorn workers (ALIGULAC-1E)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,10 @@ USER aligulac
 
 EXPOSE 8000
 
-# Start Gunicorn from the project root
+# Start Gunicorn from the project root.
+# --timeout 30 is gunicorn's default, made explicit because it must stay ABOVE
+# DB_STATEMENT_TIMEOUT_MS (25s, see aligulac.middleware.StatementTimeoutMiddleware): a slow
+# query should be cancelled by Postgres and returned as a clean 500, not run long enough for
+# the arbiter to SIGABRT the worker (the ALIGULAC-1E failure mode).
 WORKDIR /app/aligulac
-CMD ["gunicorn", "--chdir", "aligulac", "aligulac.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3", "--access-logfile", "-", "--error-logfile", "-"]
+CMD ["gunicorn", "--chdir", "aligulac", "aligulac.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3", "--timeout", "30", "--access-logfile", "-", "--error-logfile", "-"]

--- a/aligulac/aligulac/middleware.py
+++ b/aligulac/aligulac/middleware.py
@@ -1,5 +1,11 @@
 import hashlib
+import logging
+
+from django.conf import settings
+from django.db.backends.signals import connection_created
 from django.utils.encoding import force_bytes
+
+logger = logging.getLogger(__name__)
 
 class RealIPMiddleware:
     """
@@ -74,5 +80,52 @@ class ETagMiddleware:
         # cache one user's language for another.
         if not response.has_header('Cache-Control'):
             response['Cache-Control'] = 'private, no-cache, must-revalidate'
-            
+
         return response
+
+
+class StatementTimeoutMiddleware:
+    """
+    Caps Postgres ``statement_timeout`` on web-request DB connections so a runaway query
+    is cancelled by the database (surfacing as a clean HTTP 500) instead of blocking a
+    gunicorn worker until the arbiter SIGABRTs it -- the failure mode behind ALIGULAC-1E
+    (SystemExit:1 raised from gunicorn's handle_abort). The timeout
+    (settings.DB_STATEMENT_TIMEOUT_MS, default 25s) is kept below the gunicorn --timeout
+    (30s) so the DB cancels first and the worker survives.
+
+    Scope is the whole point. The timeout is applied via the ``connection_created`` signal,
+    which we connect in ``__init__``. Middleware is only instantiated by the request-handling
+    stack, so this signal is never connected in management/batch processes (e.g. rating
+    recalcs) -- their legitimately long-running queries are left uncapped. And because the
+    signal fires only when a connection is actually opened, fully cache-served requests that
+    touch no DB pay nothing.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.timeout_ms = getattr(settings, 'DB_STATEMENT_TIMEOUT_MS', 25000)
+        if self.timeout_ms and self.timeout_ms > 0:
+            connection_created.connect(
+                self._apply_statement_timeout,
+                dispatch_uid='aligulac.statement_timeout',
+            )
+
+    def _apply_statement_timeout(self, sender, connection, **kwargs):
+        # Postgres-only; ignore sqlite (tests) or any other backend.
+        if connection.vendor != 'postgresql':
+            return
+        try:
+            with connection.cursor() as cursor:
+                # set_config() rather than a bare SET so the value binds as a parameter under
+                # both psycopg2 and psycopg3 (SET does not accept bind parameters). is_local
+                # is false so it holds for the life of this (per-request) connection.
+                cursor.execute(
+                    "SELECT set_config('statement_timeout', %s, false)",
+                    [str(self.timeout_ms)],
+                )
+        except Exception:
+            # Fail open: a defensive guard that cannot arm itself must not 500 every request.
+            logger.warning('Could not set per-request statement_timeout', exc_info=True)
+
+    def __call__(self, request):
+        return self.get_response(request)

--- a/aligulac/aligulac/settings.py
+++ b/aligulac/aligulac/settings.py
@@ -190,6 +190,9 @@ if DEBUG and DEBUG_TOOLBAR:
 
 MIDDLEWARE = [
     'aligulac.middleware.RealIPMiddleware',
+    # Arms a per-request DB statement_timeout (see StatementTimeoutMiddleware). Position is
+    # not significant -- it works via the connection_created signal, not request order.
+    'aligulac.middleware.StatementTimeoutMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -213,6 +216,18 @@ WSGI_APPLICATION = 'aligulac.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
+
+# Per-request Postgres statement timeout (milliseconds), applied to web-request DB
+# connections by aligulac.middleware.StatementTimeoutMiddleware so a runaway query returns a
+# clean error instead of blocking a gunicorn worker until the arbiter SIGABRTs it (ALIGULAC-1E).
+# Keep it BELOW the gunicorn --timeout (30s) so Postgres cancels first. Set DB_STATEMENT_TIMEOUT_MS
+# to none/0 to disable. NOTE: this is request-scoped on purpose -- management/batch commands
+# (e.g. rating recalcs) don't run middleware, so their long-running queries are never capped.
+_db_statement_timeout = get_env('DB_STATEMENT_TIMEOUT_MS', 25000)
+try:
+    DB_STATEMENT_TIMEOUT_MS = int(_db_statement_timeout) if _db_statement_timeout is not None else 0
+except (TypeError, ValueError):
+    DB_STATEMENT_TIMEOUT_MS = 25000
 
 DATABASES = {
     'default': {

--- a/aligulac/ratings/models.py
+++ b/aligulac/ratings/models.py
@@ -2015,6 +2015,12 @@ class Rating(models.Model):
     class Meta:
         ordering = ['period']
         db_table = 'rating'
+        # NOTE: a covering index idx_rating_player_id_rating on (player_id, rating) exists
+        # in production for the Records > History peak-rating query. It is NOT created by
+        # Django migrations — Aligulac shares the replayman DB, so DB tuning lives in
+        # rmserv/scripts/migrations/00086-aligulac-rating-peak-index.sql. If you ever want
+        # Django to manage it, add it here as models.Index(..., name='idx_rating_player_id_rating')
+        # (same name) so Django adopts the existing index instead of creating a duplicate.
 
     # {{{ Fields
     period = models.ForeignKey(


### PR DESCRIPTION
## What

Defense-in-depth follow-up to the `rating (player_id, rating)` index in **replayman #1338**. That index removes the known slow path on **Records > History**; this guard ensures any *future* runaway query degrades to a clean 500 instead of repeating **ALIGULAC-1E**.

## The failure mode (ALIGULAC-1E)

A query on `/records/history/` outran gunicorn's **30s worker timeout**; the arbiter sent SIGABRT, gunicorn's `handle_abort` called `sys.exit(1)`, and Sentry captured the `SystemExit: 1`. Nothing returned a clean error — a worker (1 of 3) was simply killed mid-request.

## Fix

`StatementTimeoutMiddleware` arms a per-request Postgres `statement_timeout` (`settings.DB_STATEMENT_TIMEOUT_MS`, default **25s**), kept **below** the gunicorn `--timeout` (30s) so Postgres cancels the query first → Django raises `OperationalError` → clean 500 → **worker survives**.

### Why it's safe for the batch/rating-recalc jobs

The rating-recalc management commands share the `default` DB config and legitimately run multi-minute queries, so a global `statement_timeout` (e.g. in `DATABASES['OPTIONS']`) would break them. This avoids that:

- The timeout is applied via the **`connection_created` signal**, connected in the middleware's `__init__`.
- Middleware is **only instantiated by the request-handling stack** — `manage.py` commands never build the middleware chain, so the signal is never connected in batch processes. Their queries are left uncapped.
- The signal fires only when a connection is actually opened, so fully cache-served requests that touch no DB pay nothing.
- Uses `set_config()` (not a bare `SET`) so the value binds as a parameter under both psycopg2 and psycopg3, and **fails open** (logs + continues) so a guard that can't arm itself never 500s a request.

`CONN_MAX_AGE` is unset (0) → a fresh connection per web request, so the session-level setting can't leak across requests.

## Also in this PR

- **`Dockerfile`**: make gunicorn `--timeout 30` explicit (it's the default) and document why it must stay *above* `DB_STATEMENT_TIMEOUT_MS`.
- **`ratings/models.py`**: note on `Rating.Meta` that the covering index `idx_rating_player_id_rating` is maintained in replayman's shared-DB migrations (`rmserv/scripts/migrations/00086`, PR #1338), **not** by Django — so a Django-only dev isn't mystified by an index `migrate` never created, and can adopt the same index name if it's ever declared in `Meta.indexes`.

## Validation (dev Postgres)

- ✅ `py_compile` clean on `middleware.py` and `settings.py`
- ✅ An armed 200ms timeout cancels a 1s query with `canceling statement due to statement timeout`
- ✅ A fresh connection shows `statement_timeout = 0` → the cap is **per-connection**; batch processes are unaffected

## Sequencing

Independent of #1338, but #1338 is the actual fix for the current hotspot; this is the safety net. Leave **ALIGULAC-1E** unresolved until #1338 deploys.

> ⚠️ This branch's commit is **unsigned** — GPG signing couldn't complete in the dev environment (pinentry timeout). Re-sign/amend if signed commits are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)