### PR TITLE
Performance workstream rollup

### DIFF
--- a/aligulac/aligulac/settings.py
+++ b/aligulac/aligulac/settings.py
@@ -222,6 +222,13 @@ DATABASES = {
         'PASSWORD': local.DB_PASSWORD,
         'HOST': local.DB_HOST,
         'PORT': local.DB_PORT,
+        # Reuse backend connections across requests instead of opening (and
+        # TLS-handshaking + re-running SET search_path on) a fresh connection
+        # per request. With the 3 sync gunicorn workers steady-state persistent
+        # backends stay at ~3, well under max_connections, so no pooler is
+        # needed. CONN_HEALTH_CHECKS validates a reused connection before use.
+        'CONN_MAX_AGE': int(get_env('DB_CONN_MAX_AGE', '60')),
+        'CONN_HEALTH_CHECKS': True,
         'OPTIONS': {
             'sslmode': getattr(local, 'DB_SSLMODE', 'prefer'),
             'options': f'-c search_path={DB_SCHEMA}',

--- a/aligulac/aligulac/tools.py
+++ b/aligulac/aligulac/tools.py
@@ -44,7 +44,7 @@ from ratings.models import (
     TYPE_EVENT
 )
 from ratings.templatetags.ratings_extras import urlfilter
-from ratings.tools import get_latest_period, find_player
+from ratings.tools import get_latest_period, get_latest_period_no_cache, find_player
 
 # }}}
 

--- a/aligulac/aligulac/tools.py
+++ b/aligulac/aligulac/tools.py
@@ -44,7 +44,7 @@ from ratings.models import (
     TYPE_EVENT
 )
 from ratings.templatetags.ratings_extras import urlfilter
-from ratings.tools import get_latest_period, get_latest_period_no_cache, find_player
+from ratings.tools import get_latest_period, find_player
 
 # }}}
 

--- a/aligulac/ratings/api/resources.py
+++ b/aligulac/ratings/api/resources.py
@@ -110,7 +110,7 @@ class SmallRatingResource(ModelResource):
 
 class RatingResource(ModelResource):
     class Meta:
-        queryset = total_ratings(Rating.objects.all())
+        queryset = total_ratings(Rating.objects.all()).select_related('player')
         allowed_methods = ['get', 'post']
         resource_name = 'rating'
         authentication = APIKeyAuthentication()
@@ -156,7 +156,7 @@ class RatingResource(ModelResource):
 
 class ActiveRatingResource(ModelResource):
     class Meta:
-        queryset = filter_active(total_ratings(Rating.objects.all()))
+        queryset = filter_active(total_ratings(Rating.objects.all())).select_related('player')
         allowed_methods = ['get', 'post']
         resource_name = 'activerating'
         authentication = APIKeyAuthentication()
@@ -356,7 +356,7 @@ class EventResource(ModelResource):
 
 class MatchResource(ModelResource):
     class Meta:
-        queryset = Match.objects.all()
+        queryset = Match.objects.select_related('pla', 'plb', 'rta', 'rtb', 'eventobj')
         allowed_methods = ['get', 'post']
         resource_name = 'match'
         authentication = APIKeyAuthentication()
@@ -410,7 +410,7 @@ class MatchResource(ModelResource):
 
 class EarningResource(ModelResource):
     class Meta:
-        queryset = Earnings.objects.all()
+        queryset = Earnings.objects.select_related('event', 'player')
         allowed_methods = ['get', 'post']
         resource_name = 'earning'
         authentication = APIKeyAuthentication()

--- a/aligulac/ratings/comparisons.py
+++ b/aligulac/ratings/comparisons.py
@@ -299,8 +299,8 @@ class FormComparison(Comparison):
     def _get_value(self, player):
         if player.id not in self.forms:
             matches = Match.objects.symmetric_filter(pla=player) \
-                .order_by('-date')
-            recent_matches = matches[:min(5, len(matches))]
+                .order_by('-date', '-id')
+            recent_matches = list(matches[:5])
             self.forms[player.id] = [
                 self.winner_to_char(player, m) for m in recent_matches
             ]

--- a/aligulac/ratings/ranking_views.py
+++ b/aligulac/ratings/ranking_views.py
@@ -1,5 +1,6 @@
 # {{{ Imports
 from django.db.models import (
+    Prefetch,
     Q,
     Sum,
 )
@@ -21,6 +22,7 @@ from aligulac.tools import (
 )
 from ratings.models import (
     Earnings,
+    GroupMembership,
     P,
     Period,
     Player,
@@ -305,12 +307,26 @@ def earnings(request):
         if nitems > 0:
             ranking_list = list(ranking_qset[(actual_page - 1) * pagesize: actual_page * pagesize])
             
-            # Populate with player and team objects
+            # Populate with player and team objects. Prefetch current-team
+            # memberships so resolving each player's team is a single extra
+            # query instead of one get_current_team() query per row.
             ids = [p['player'] for p in ranking_list]
-            players = Player.objects.in_bulk(ids)
+            players = Player.objects.filter(id__in=ids).prefetch_related(
+                Prefetch(
+                    'groupmembership_set',
+                    queryset=(
+                        GroupMembership.objects
+                        .filter(current=True, group__is_team=True)
+                        .select_related('group')
+                        .order_by('id')
+                    ),
+                    to_attr='current_team_memberships',
+                )
+            ).in_bulk()
             for p in ranking_list:
                 p['playerobj'] = players[p['player']]
-                p['teamobj'] = p['playerobj'].get_current_team()
+                memberships = p['playerobj'].current_team_memberships
+                p['teamobj'] = memberships[0].group if memberships else None
         else:
             ranking_list = []
 

--- a/aligulac/ratings/records_views.py
+++ b/aligulac/ratings/records_views.py
@@ -140,7 +140,7 @@ def hof(request):
     def get_hof():
         return list(Player.objects.filter(
             dom_val__isnull=False, dom_start__isnull=False, dom_end__isnull=False, dom_val__gt=0
-        ).order_by('-dom_val'))
+        ).select_related('dom_start', 'dom_end').order_by('-dom_val'))
 
     from aligulac.cache import cached_query
     from django.conf import settings

--- a/aligulac/ratings/tools.py
+++ b/aligulac/ratings/tools.py
@@ -1,4 +1,5 @@
 # {{{ Imports
+import logging
 import shlex
 from datetime import date
 from decimal import Decimal
@@ -38,6 +39,8 @@ from ratings.models import (
 )
 
 # }}}
+
+logger = logging.getLogger(__name__)
 
 # {{{ Patchlist
 PATCHES = [
@@ -380,7 +383,14 @@ def get_latest_period_no_cache():
     rankings)."""
     try:
         return Period.objects.filter(computed=True).latest('start')
-    except:
+    except Period.DoesNotExist:
+        # No computed period exists yet (e.g. a fresh DB) — expected, stay quiet.
+        return None
+    except Exception:
+        # Operational DB failure: keep the historical "return None" behavior but
+        # surface it instead of failing silently; don't swallow BaseException
+        # (KeyboardInterrupt / SystemExit).
+        logger.exception('get_latest_period_no_cache: failed to load latest period')
         return None
 
 
@@ -388,11 +398,29 @@ def get_latest_period():
     try:
         period_id = cache.get(LATEST_PERIOD_CACHE_KEY)
         if period_id is not None:
-            return Period.objects.get(id=period_id)
+            try:
+                return Period.objects.get(id=period_id)
+            except (Period.DoesNotExist, ValueError, TypeError):
+                # Stale/garbage cached id (e.g. the cache outlived a DB
+                # restore/flush): treat it as a miss, drop the key, and fall
+                # through to recompute the latest period below rather than
+                # serving None for the whole TTL window.
+                logger.warning(
+                    'get_latest_period: stale cached period id %r; dropping key '
+                    'and re-querying', period_id,
+                )
+                cache.delete(LATEST_PERIOD_CACHE_KEY)
         period = Period.objects.filter(computed=True).latest('start')
         cache.set(LATEST_PERIOD_CACHE_KEY, period.id, LATEST_PERIOD_CACHE_TTL)
         return period
-    except:
+    except Period.DoesNotExist:
+        # No computed period exists yet (e.g. a fresh DB) — expected, stay quiet.
+        return None
+    except Exception:
+        # Operational cache/DB failure: degrade to "no latest period" (the
+        # pre-cache behavior) but log it; don't swallow BaseException
+        # (KeyboardInterrupt / SystemExit).
+        logger.exception('get_latest_period: failed to load latest period')
         return None
 
 

--- a/aligulac/ratings/tools.py
+++ b/aligulac/ratings/tools.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from math import sqrt
 
 import ccy
+from django.core.cache import cache
 from django.db.models import (
     Sum,
     Q
@@ -219,7 +220,7 @@ def find_player(query=None, lst=None, make=False, soft=False, strict=False):
     # }}}
 
     # {{{ If no results, make player if allowed
-    if not queryset.exists() and make:
+    if make and not queryset.exists():
         # {{{ Raise exceptions if missing crucial data
         if tag == None:
             msg = _("Player '%s' was not found and cound not be made (missing player tag)") % ' '.join(lst)
@@ -353,9 +354,44 @@ def icdf(c, loc=0.0, scale=1.0):
 # }}}
 
 # {{{ get_latest_period: Returns the latest computed period, or None.
-def get_latest_period():
+# Called on essentially every server-rendered request via base_ctx; the value
+# only changes after the quad-daily recompute, so cache the id for the same
+# 15-minute staleness window already accepted for ranking/period views.
+#
+# IMPORTANT: get_latest_period() is also called by the recompute batch scripts
+# (teamranks.py, teamratings.py, simul/playerlist.py via make_player) which
+# PERSIST team rankings filtered by the returned period. Those must never read a
+# stale period, so:
+#   * recompute.py busts LATEST_PERIOD_CACHE_KEY after computing a new period
+#     (right before it launches the batch scripts); see recompute.py.
+#   * the batch scripts call get_latest_period_no_cache() to query the DB
+#     directly, bypassing the cache entirely as defense-in-depth.
+# Import LATEST_PERIOD_CACHE_KEY wherever the cache is busted so the producer and
+# the buster cannot drift.
+LATEST_PERIOD_CACHE_KEY = 'aligulac:latest_period_id'
+LATEST_PERIOD_CACHE_TTL = 15 * 60
+
+
+def get_latest_period_no_cache():
+    """Return the latest computed Period straight from the DB, or None.
+
+    Bypasses the cache. Use this from any code path that must observe a
+    just-computed period (e.g. the recompute batch scripts that persist team
+    rankings)."""
     try:
         return Period.objects.filter(computed=True).latest('start')
+    except:
+        return None
+
+
+def get_latest_period():
+    try:
+        period_id = cache.get(LATEST_PERIOD_CACHE_KEY)
+        if period_id is not None:
+            return Period.objects.get(id=period_id)
+        period = Period.objects.filter(computed=True).latest('start')
+        cache.set(LATEST_PERIOD_CACHE_KEY, period.id, LATEST_PERIOD_CACHE_TTL)
+        return period
     except:
         return None
 

--- a/aligulac/recompute.py
+++ b/aligulac/recompute.py
@@ -148,8 +148,8 @@ for i in range(earliest.id, latest.id + 1):
 # the recompute, so swallow any error.
 try:
     cache.delete(LATEST_PERIOD_CACHE_KEY)
-except Exception:
-    print('[%s] WARNING: failed to bust latest-period cache' % str(datetime.now()), flush=True)
+except Exception as e:
+    print('[%s] WARNING: failed to bust latest-period cache: %r' % (str(datetime.now()), e), flush=True)
 
 if 'debug' not in sys.argv:
     subprocess.call([os.path.join(PROJECT_PATH, 'smoothing.py')])

--- a/aligulac/recompute.py
+++ b/aligulac/recompute.py
@@ -34,12 +34,14 @@ def acquire_lock():
 
 acquire_lock()
 
+from django.core.cache import cache
 from django.db.models import F, Q
 from django.db.transaction import atomic
 
 from aligulac.settings import PROJECT_PATH
 
 from ratings.models import Match, Period, Player
+from ratings.tools import LATEST_PERIOD_CACHE_KEY
 
 print('[%s] Checking for Match <-> Period artifacts... ' % (str(datetime.now())), end="")
 
@@ -136,6 +138,18 @@ print('[%s] Recomputing periods %i through %i' % (str(datetime.now()), earliest.
 
 for i in range(earliest.id, latest.id + 1):
     subprocess.call([os.path.join(PROJECT_PATH, 'period.py'), str(i)])
+
+# period.py sets period.computed=True as it recomputes each period, so a newly
+# computed latest period now exists in the DB. base_ctx caches the latest-period
+# id (ratings.tools.get_latest_period) for up to 15 minutes; bust that key here,
+# before the team-ranking batch scripts run, so neither they nor live web traffic
+# read a stale period. (The batch scripts also query the DB directly via
+# get_latest_period_no_cache as defense-in-depth.) A cache outage must not abort
+# the recompute, so swallow any error.
+try:
+    cache.delete(LATEST_PERIOD_CACHE_KEY)
+except Exception:
+    print('[%s] WARNING: failed to bust latest-period cache' % str(datetime.now()), flush=True)
 
 if 'debug' not in sys.argv:
     subprocess.call([os.path.join(PROJECT_PATH, 'smoothing.py')])

--- a/aligulac/simul/playerlist.py
+++ b/aligulac/simul/playerlist.py
@@ -10,7 +10,7 @@ from ratings.models import (
 )
 from ratings.tools import (
     cdf,
-    get_latest_period,
+    get_latest_period_no_cache,
 )
 
 debug = False
@@ -34,7 +34,7 @@ def make_player(player):
         pl = Player(
             player.tag,
             player.race,
-            start_rating(player.country, etn(lambda: get_latest_period().id) or 1), 0.0, 0.0, 0.0,
+            start_rating(player.country, etn(lambda: get_latest_period_no_cache().id) or 1), 0.0, 0.0, 0.0,
             INIT_DEV, INIT_DEV, INIT_DEV, INIT_DEV,
         )
 

--- a/aligulac/teamranks.py
+++ b/aligulac/teamranks.py
@@ -11,13 +11,11 @@ import django
 
 django.setup()
 
-from aligulac.tools import get_latest_period_no_cache
-
 from ratings.models import (
     Group,
     Rating,
 )
-from ratings.tools import filter_active
+from ratings.tools import filter_active, get_latest_period_no_cache
 
 from simul.formats.teamak import TeamAK
 from simul.formats.teampl import TeamPL

--- a/aligulac/teamranks.py
+++ b/aligulac/teamranks.py
@@ -11,7 +11,7 @@ import django
 
 django.setup()
 
-from aligulac.tools import get_latest_period
+from aligulac.tools import get_latest_period_no_cache
 
 from ratings.models import (
     Group,
@@ -30,7 +30,9 @@ nplayers_min = 6 if proleague else 1
 Simulator = TeamPL if proleague else TeamAK
 
 # {{{ Get a list of teams that can compete
-curp = get_latest_period()
+# Bypass the cache: this batch script persists team rankings and must see the
+# period just computed by recompute.py, not a possibly-stale cached id.
+curp = get_latest_period_no_cache()
 allowed_teams = []
 teams = Group.objects.filter(active=True, is_team=True)
 for t in teams:

--- a/aligulac/teamratings.py
+++ b/aligulac/teamratings.py
@@ -8,7 +8,7 @@ import django
 
 django.setup()
 
-from aligulac.tools import get_latest_period
+from aligulac.tools import get_latest_period_no_cache
 
 from ratings.models import (
     Group,
@@ -19,7 +19,9 @@ from ratings.tools import filter_active
 print('[%s] Updating team ratings' % str(datetime.now()), flush=True)
 
 # {{{ Update ratings
-curp = get_latest_period()
+# Bypass the cache: this batch script persists team meanrating and must see the
+# period just computed by recompute.py, not a possibly-stale cached id.
+curp = get_latest_period_no_cache()
 for team in Group.objects.filter(active=True, is_team=True):
     ratings = filter_active(Rating.objects.filter(
         period=curp,

--- a/aligulac/teamratings.py
+++ b/aligulac/teamratings.py
@@ -8,13 +8,11 @@ import django
 
 django.setup()
 
-from aligulac.tools import get_latest_period_no_cache
-
 from ratings.models import (
     Group,
     Rating,
 )
-from ratings.tools import filter_active
+from ratings.tools import filter_active, get_latest_period_no_cache
 
 print('[%s] Updating team ratings' % str(datetime.now()), flush=True)
 

--- a/templates/period.djhtml
+++ b/templates/period.djhtml
@@ -287,7 +287,7 @@ This template shows a rating list for a given period.
               {% for e in updown %}
                 <tr>
                   <td class="small text-right" style="vertical-align: bottom;">
-                    <a href="/players/{{e.0.player.id}}-{{e.0.player.tag|urlfilter}}/period/{{e.0.period.id}}/">
+                    <a href="/players/{{e.0.player.id}}-{{e.0.player.tag|urlfilter}}/period/{{e.0.period_id}}/">
                       {{e.0.diff|ratscalediff|signify}}
                     </a>
                   </td>
@@ -295,7 +295,7 @@ This template shows a rating list for a given period.
                     {{e.0.player|player}}
                   </td>
                   <td class="small text-right" style="vertical-align: bottom;">
-                    <a href="/players/{{e.1.player.id}}-{{e.1.player.tag|urlfilter}}/period/{{e.1.period.id}}/">
+                    <a href="/players/{{e.1.player.id}}-{{e.1.player.tag|urlfilter}}/period/{{e.1.period_id}}/">
                       {{e.1.diff|ratscalediff|signify}}
                     </a>
                   </td>

--- a/templates/ratinglist.djhtml
+++ b/templates/ratinglist.djhtml
@@ -206,7 +206,7 @@ example.)
               <!-- Link to adjustments -->
               <td class="rl_arrow {% if not rl_small %}hidden-xs{% endif %}">
                 {% if entry.decay == 0 %}
-                  <a href="/players/{{ entry.player.id }}-{{ entry.player.tag|urlfilter }}/period/{{ entry.period.id }}/">
+                  <a href="/players/{{ entry.player.id }}-{{ entry.player.tag|urlfilter }}/period/{{ entry.period_id }}/">
                     <span class="right-caret"></span>
                   </a>
                 {% endif %}


### PR DESCRIPTION
        - settings: add CONN_MAX_AGE + CONN_HEALTH_CHECKS for persistent Postgres
          connections (eliminates a fresh connect + TLS + SET search_path per request).
        - tools: cache get_latest_period() (called on essentially every server-rendered
          page via base_ctx); add get_latest_period_no_cache() for the recompute batch
          scripts, and bust the cache key in recompute.py after a new period is computed
          so team rankings are never persisted against a stale period.
        - tools: short-circuit find_player() on the read-only (make=False) path so the
          heavy cross-table OR-join no longer runs an extra time per search.
        - comparisons: FormComparison selects the recent five via ORDER BY date DESC,
          id DESC LIMIT 5 at the DB instead of materializing the full match set with len().
        - api/resources: select_related on the Rating/ActiveRating/Match/Earning list
          resources to eliminate per-row FK N+1 on the list endpoints.
        - records_views: select_related dom_start/dom_end Period FKs in get_hof().
        - ranking_views: prefetch current-team memberships in the earnings ranking
          instead of one get_current_team() query per row.
        - templates: use period_id instead of period.id in ratinglist/period to drop
          the per-row Period FK fetch.