### PR TITLE
Prevent rendering escaped HTML in Message objects

### DIFF
--- a/aligulac/aligulac/tools.py
+++ b/aligulac/aligulac/tools.py
@@ -24,6 +24,7 @@ from django.db.models import Q
 from django.http import HttpResponse
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from aligulac.cache import cache_page
@@ -165,7 +166,17 @@ class NotUniquePlayerMessage(Message):
 
 # {{{ generate_messages: Generates a list of message objects for an object that supports them.
 def generate_messages(obj):
-    return [Message(m.get_message(), m.get_title(), m.type) for m in obj.message_set.all()]
+    # Message-model rows are editor/staff-curated (Django admin + seed data) and
+    # their params intentionally carry HTML (e.g. the 'Possible confusion'
+    # %(player)s links). messages.djhtml deliberately auto-escapes plain-str
+    # message text so user-submitted echoes can't become a reflected-XSS sink,
+    # and relies on trusted-HTML messages being SafeStrings (as
+    # NotUniquePlayerMessage already is via render_to_string). Mark this trusted
+    # HTML safe, or the links render as escaped literal text.
+    return [
+        Message(mark_safe(m.get_message()), m.get_title(), m.type)
+        for m in obj.message_set.all()
+    ]
 
 
 # }}}


### PR DESCRIPTION
Mark messages as safe to ensure that trusted HTML content in messages is rendered correctly. 

**Safe rendering of trusted HTML in messages:**

* Updated `generate_messages` in `aligulac/tools.py` to wrap message text with `mark_safe`, ensuring that trusted HTML content (such as links) is rendered properly instead of being escaped as plain text. This prevents issues where editor-curated messages containing HTML would otherwise display incorrectly.
* Added the necessary import for `mark_safe` from `django.utils.safestring` in `aligulac/tools.py`.