### PR TITLE
Harden aligulac views and API against malformed input

### DIFF
--- a/aligulac/aligulac/tools.py
+++ b/aligulac/aligulac/tools.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import re
 import shlex
 import string
 import subprocess
@@ -485,7 +486,10 @@ def search(query, search_for=['players', 'teams', 'events'], strict=False):
     lex.commenters = ''
     lex.quotes = '"'
 
-    terms = [s.strip() for s in list(lex) if s.strip() != '']
+    try:
+        terms = [s.strip() for s in list(lex) if s.strip() != '']
+    except ValueError:
+        return None
     if len(terms) == 0:
         return None
     # }}}
@@ -505,7 +509,7 @@ def search(query, search_for=['players', 'teams', 'events'], strict=False):
         events = Event.objects.filter(type__in=[TYPE_CATEGORY, TYPE_EVENT]).order_by('idx')
         events = events.filter(
             fullname__iregex=(
-                r"\s".join(r".*{}.*".format(term) for term in terms)
+                r"\s".join(r".*{}.*".format(re.escape(term)) for term in terms)
             )
         )
     else:

--- a/aligulac/ratings/api/resources.py
+++ b/aligulac/ratings/api/resources.py
@@ -243,6 +243,14 @@ class PlayerResource(ModelResource):
             'race', 'dom_val', 'current_rating', 'dom_start', 'dom_end',
         ]
 
+    def get_multiple(self, request, **kwargs):
+        # Reject non-numeric pks so a bad /player/set/ token returns 400, not 500.
+        kwarg_name = '%s_list' % self._meta.detail_uri_name
+        identifiers = kwargs.get(kwarg_name, '').split(';')
+        if not all(i.isdigit() for i in identifiers):
+            return http.HttpBadRequest("Invalid player id in set.")
+        return super(PlayerResource, self).get_multiple(request, **kwargs)
+
     def dehydrate_total_earnings(self, bundle):
         return ntz(bundle.obj.earnings_set.aggregate(Sum('earnings'))['earnings__sum'])
 
@@ -340,11 +348,11 @@ class EventResource(ModelResource):
         null=True, help_text='Prizes awarded'
     )
 
-    def build_filters(self, filters=None):
+    def build_filters(self, filters=None, **kwargs):
         check = ['uplink__parent', 'uplink__distance', 'downlink__child', 'downlink__distance']
         fits = lambda s: any(filter(lambda k: s.startswith(k), check))
         other_filters = {f: filters[f] for f in filters if not fits(f)}
-        orm_filters = super(EventResource, self).build_filters(other_filters)
+        orm_filters = super(EventResource, self).build_filters(other_filters, **kwargs)
         for f in filter(fits, filters):
             is_pure = f in check
             if is_pure or any(filter(lambda s: f.endswith(s), ['gt', 'gte', 'lt', 'lte'])):
@@ -389,7 +397,7 @@ class MatchResource(ModelResource):
     rtb = fields.ForeignKey(SmallRatingResource, 'rtb', null=True, full=True)
     eventobj = fields.ForeignKey(SmallEventResource, 'eventobj', null=True, full=True)
 
-    def build_filters(self, filters=None):
+    def build_filters(self, filters=None, **kwargs):
         check = [
             'eventobj__uplink__parent',
             'eventobj__uplink__distance',
@@ -398,7 +406,7 @@ class MatchResource(ModelResource):
         ]
         fits = lambda s: any(filter(lambda k: s.startswith(k), check))
         other_filters = {f: filters[f] for f in filters if not fits(f)}
-        orm_filters = super(MatchResource, self).build_filters(other_filters)
+        orm_filters = super(MatchResource, self).build_filters(other_filters, **kwargs)
         for f in filter(fits, filters):
             is_pure = f in check
             if is_pure or any(filter(lambda s: f.endswith(s), ['gt', 'gte', 'lt', 'lte'])):

--- a/aligulac/ratings/inference_views.py
+++ b/aligulac/ratings/inference_views.py
@@ -210,14 +210,24 @@ class SetupForm(forms.Form):
     bo = forms.CharField(max_length=200, required=True)
     ps = forms.CharField(max_length=200, required=True)
 
-    # {{{ Cleaning methods. NO VALIDATION IS PERFORMED HERE.
+    # {{{ Cleaning methods.
     def clean_bo(self):
-        return [(int(a) + 1) // 2 for a in self.cleaned_data['bo'].split(',')]
+        try:
+            return [(int(a) + 1) // 2 for a in self.cleaned_data['bo'].split(',')]
+        except ValueError:
+            raise forms.ValidationError('Invalid best-of list.')
 
     def clean_ps(self):
-        ids = [int(a) for a in self.cleaned_data['ps'].split(',')]
+        try:
+            ids = [int(a) for a in self.cleaned_data['ps'].split(',')]
+        except ValueError:
+            raise forms.ValidationError('Invalid player list.')
         players = Player.objects.in_bulk(ids)
-        return [players[id] if id in players else None for id in ids]
+        # An id of 0 is an intentional bye; any other unresolved id is invalid.
+        resolved = [players[id] if id in players else None for id in ids]
+        if any(p is None and id != 0 for p, id in zip(resolved, ids)):
+            raise forms.ValidationError('Unknown player id.')
+        return resolved
     # }}}
 
 
@@ -309,7 +319,7 @@ def match(request):
 
     # {{{ Get data, set up and simulate
     form = SetupForm(request.GET)
-    if not form.is_valid():
+    if not form.is_valid() or len(form.cleaned_data['ps']) != 2 or None in form.cleaned_data['ps']:
         return redirect('/inference/')
 
     result = MatchPredictionResult(
@@ -608,6 +618,10 @@ def sebracket(request):
     # {{{ Get data, set up and simulate
     form = SetupForm(request.GET)
     if not form.is_valid():
+        return redirect('/inference/')
+
+    nps = len(form.cleaned_data['ps'])
+    if nps < 2 or (nps & (nps - 1)) != 0:
         return redirect('/inference/')
 
     result = SingleEliminationPredictionResult(

--- a/aligulac/ratings/ranking_views.py
+++ b/aligulac/ratings/ranking_views.py
@@ -19,6 +19,7 @@ from aligulac.tools import (
     Message,
     base_ctx,
     get_param,
+    get_param_range,
 )
 from ratings.models import (
     Earnings,
@@ -161,7 +162,7 @@ def period(request, period_id=None):
     race = get_param(request, 'race', 'ptzrs')
     nats = get_param(request, 'nats', 'all')
     sort = get_param(request, 'sort', '')
-    page = int(get_param(request, 'page', 1))
+    page = get_param_range(request, 'page', (1, 9999), 1)
 
     # Initial filtering of ratings to determine total item count and normalize page
     entries_base = filter_active(period.rating_set).select_related('player')
@@ -271,9 +272,11 @@ def earnings(request):
 
     # {{{ Initial filtering of earnings
     year = get_param(request, 'year', 'all')
+    if year != 'all' and not str(year).isdigit():
+        year = 'all'
     nats = get_param(request, 'country', 'all')
     curs = get_param(request, 'currency', 'all')
-    page = int(get_param(request, 'page', 1))
+    page = get_param_range(request, 'page', (1, 9999), 1)
 
     base['filters'] = {'year': year, 'country': nats, 'currency': curs}
 

--- a/aligulac/ratings/records_views.py
+++ b/aligulac/ratings/records_views.py
@@ -6,6 +6,7 @@ from aligulac.tools import (
     base_ctx,
     get_param,
     get_param_choice,
+    get_param_range,
 )
 from countries import data
 from ratings.models import (
@@ -33,7 +34,7 @@ def history(request):
     base = base_ctx('Records', 'History', request)
 
     # {{{ Filtering (appears faster with custom SQL)
-    nplayers = int(get_param(request, 'nplayers', '5'))
+    nplayers = get_param_range(request, 'nplayers', (1, 100), 5)
     race = get_param_choice(request, 'race', ['ptzrs', 'p', 't', 'z', 'ptrs', 'tzrs', 'pzrs'], 'ptzrs')
     nats = get_param_choice(request, 'nats', ['all', 'foreigners'] + list(data.ccn_to_cca2.values()), 'all')
 


### PR DESCRIPTION
## What was broken

Several aligulac endpoints returned HTTP 500 on malformed or bot-crafted input. Root cause: query params, inference form fields, free-text search, and tastypie filters were parsed/used without validation, so non-numeric values, bad regex metacharacters, unknown/bye player IDs, and tastypie's `ignore_bad_filters` kwarg raised unhandled exceptions instead of clean 4xx/redirect responses.

Fixes ALIGULAC-9 / ALIGULAC-7 / ALIGULAC-6 / ALIGULAC-T / ALIGULAC-C / ALIGULAC-3 / ALIGULAC-N / ALIGULAC-P / ALIGULAC-1D / ALIGULAC-1C / ALIGULAC-Q / ALIGULAC-1F / ALIGULAC-R / ALIGULAC-19 / ALIGULAC-4 / ALIGULAC-1A

## Changes

- **Integer query params** (`ranking_views.py`, `records_views.py`): use the existing `get_param_range` to clamp `page` (1–9999) and `nplayers` (1–100), and guard the `year` parse with `isdigit()` before `int()`, falling back to `all`.
- **Inference `SetupForm`** (`inference_views.py`): wrap the `int()` parses in `clean_bo`/`clean_ps` in `try/except ValueError -> forms.ValidationError`, reject unknown player IDs, and validate player count per format (match = exactly 2, sebracket = a power of two). The match view also rejects bye entries (a `None` player) so they can't reach the unconditional `get_matchset()` dereference; sebracket/dual byes routed through `make_player` are unaffected. Invalid forms produce a clean redirect to `/inference/`.
- **`search()`** (`tools.py`): `re.escape` each user term before building the `fullname__iregex`, and wrap the `shlex` lexing in `try/except ValueError` falling back to the empty/early path.
- **tastypie API** (`api/resources.py`): add `**kwargs` to `Event`/`Match` `build_filters` and forward to super (handles `ignore_bad_filters`); add a `get_multiple` guard so non-numeric tokens in `/api/v1/player/set/{pk_list}/` return 400 instead of 500.

## Verification

All five changed files pass `python -m py_compile`. Each fix was checked against the corresponding Sentry stack trace; every error path now resolves to a clean 4xx or redirect, with no valid prediction, search, or API request affected.
