### PR TITLE
Fix AttributeError 500s from non-QuerySet returns and unguarded None in ratings views

### DIFF
--- a/aligulac/ratings/ranking_views.py
+++ b/aligulac/ratings/ranking_views.py
@@ -4,6 +4,7 @@ from django.db.models import (
     Q,
     Sum,
 )
+from django.http import Http404
 from django.shortcuts import (
     get_object_or_404,
     render,
@@ -66,6 +67,9 @@ def period(request, period_id=None):
         period = base['curp']
     else:
         period = get_object_or_404(Period, id=period_id, computed=True)
+
+    if period is None:
+        raise Http404
 
     if period.is_preview():
         base['messages'].append(Message(msg_preview % django_date_filter(period.end, 'F jS'), type=Message.INFO))
@@ -190,7 +194,7 @@ def period(request, period_id=None):
         entries = entries.prefetch_related('prev')
         
         # Slice the queryset without evaluating it to a list yet
-        entries_slice = entries[(actual_page - 1) * pagesize: actual_page * pagesize] if actual_page > 0 else []
+        entries_slice = entries[(actual_page - 1) * pagesize: actual_page * pagesize] if actual_page > 0 else entries.none()
 
         # populate_teams needs to prefetch on the queryset object
         populated_data = populate_teams(entries_slice)

--- a/aligulac/ratings/tools.py
+++ b/aligulac/ratings/tools.py
@@ -142,7 +142,7 @@ def find_player(query=None, lst=None, make=False, soft=False, strict=False):
         try:
             lst = [s.strip() for s in shlex.split(query) if s.strip() != '']
         except:
-            return []
+            return Player.objects.none()
 
     tag, country, race = None, None, None
 


### PR DESCRIPTION
## What was broken

Several ranking/search views returned 500 (`AttributeError`) because two code paths produced non-QuerySet / `None` values that callers then treated as QuerySets or live objects.

Root cause: `find_player()` returned a bare `[]` on a parse failure (callers call `.exists()/.count()/.first()` on it), and the `period()` ranking view passed a bare `[]` to `populate_teams()` (which calls `.prefetch_related()`) on the zero-row page and dereferenced a possibly-`None` latest period on `/periods/latest/`.

## Fixes

- `ratings/tools.py` — `find_player()`: on `shlex.split` parse failure return `Player.objects.none()` instead of `[]`, so all `query=` callers' QuerySet methods are satisfied and the error path renders a clean "no matches" form instead of crashing. The function's other two returns are already QuerySets.
- `ratings/ranking_views.py`:
  - `period()` entries path: replace the `else []` empty-page branch with `entries.none()`, a valid empty `Rating` QuerySet that `populate_teams()` can prefetch and iterate.
  - `/periods/latest/`: guard the resolved period with `if period is None: raise Http404` before calling `period.is_preview()` / `base['curp'].id`, since `get_latest_period()` can return `None` on `DoesNotExist`/operational error. `Http404` is imported.

## Fixes

Fixes ALIGULAC-A / ALIGULAC-S / ALIGULAC-B / ALIGULAC-5 / ALIGULAC-2 / ALIGULAC-J / ALIGULAC-Z

## Verification

- Confirmed each fix against the live Sentry stacktraces (`list.exists`, `list.prefetch_related`, `NoneType.is_preview`).
- Audited all `find_player()` callers: the `query=`-based ones use QuerySet methods satisfied by `.none()`; `lst=` callers bypass the parse branch.
- `python -m py_compile` passes on both files.
